### PR TITLE
Bugfix: ParseInt expects bit size not byte size

### DIFF
--- a/ebml/type.go
+++ b/ebml/type.go
@@ -248,13 +248,13 @@ func newField(t reflect.StructField, index int, tag string) (*field, error) {
 func newDefault(t reflect.Type, v string) (interface{}, error) {
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return strconv.ParseInt(v, 10, int(t.Size()))
+		return strconv.ParseInt(v, 10, int(t.Size())*8)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return strconv.ParseUint(v, 10, int(t.Size()))
+		return strconv.ParseUint(v, 10, int(t.Size())*8)
 	case reflect.Bool:
 		return strings.ToLower(v) != "false", nil
 	case reflect.Float32, reflect.Float64:
-		return strconv.ParseFloat(v, int(t.Size()))
+		return strconv.ParseFloat(v, int(t.Size())*8)
 	case reflect.String:
 		return v, nil
 	default:


### PR DESCRIPTION
This will fix errors that happen on WebM/MKV file parsing due to incorrect ParseInt usage in `newDefault`.
Previously, the returned video width was always incorrect (zero) but with the fix included it reports correct values (e.g. 1920 pixels).

![Errors](https://puu.sh/BS1pB/a40647209b.png)
![ParseInt](https://puu.sh/BS1Ak/1cb275a815.png)
![t.Size](https://puu.sh/BS1z9/7041ce0cb6.png)

**Before**, 0x0 video size:
![](https://puu.sh/BRWAa/950e8f7cf2.png)

**After**, 1280x720 video size properly recognized:
![](https://puu.sh/BS1D1/c7f52c1810.png)